### PR TITLE
Refresh & Update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,8 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-url = "1.7"
-url_serde = "0.2"
-indexmap = { version = "1.3.2", features = ["serde-1"] }
+url = { version = "2", features = ["serde"] }
+indexmap = { version = "1.6", features = ["serde-1"] }
 
 [dev-dependencies]
-pretty_assertions = "0.5"
+pretty_assertions = "0.7"

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -31,7 +31,6 @@ pub struct Spec {
     /// with a
     /// [url](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#serverUrl)
     /// value of `/`.
-    // FIXME: Provide a default value as specified in documentation instead of `None`.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub servers: Vec<Server>,
 

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -587,8 +587,6 @@ pub struct Response {
 /// See <https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#headerObject>.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 pub struct Header {
-    // FIXME: Is the third change properly implemented?
-    // FIXME: Merge `ObjectOrReference<Header>::Reference` and `ParameterOrRef::Reference`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub required: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -959,13 +959,6 @@ pub struct Callback(
 /// When a list of Security Requirement Objects is defined on the [OpenAPI Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#oasObject) or [Operation Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#operationObject), only one of the Security Requirement Objects in the list needs to be satisfied to authorize the request.
 pub type SecurityRequirement = IndexMap<Str, Vec<Str>>;
 
-// FIXME: Implement
-// /// Allows configuration of the supported OAuth Flows.
-// /// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#oauthFlowsObject
-// #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
-// pub struct OAuthFlows {
-// }
-
 /// Adds metadata to a single tag that is used by the
 /// [Operation Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#operationObject).
 /// It is not mandatory to have a Tag Object per tag defined in the Operation Object instances.

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -660,24 +660,23 @@ pub struct RequestBody {
 pub struct Link {
     #[serde(flatten)]
     operation: LinkOperation,
-    // FIXME: Implement
-    // /// A map representing parameters to pass to an operation as specified with `operationId`
-    // /// or identified via `operationRef`. The key is the parameter name to be used, whereas
-    // /// the value can be a constant or an expression to be evaluated and passed to the
-    // /// linked operation. The parameter name can be qualified using the
-    // /// [parameter location](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#parameterIn)
-    // /// `[{in}.]{name}` for operations that use the same parameter name in different
-    // /// locations (e.g. path.id).
-    // parameters: IndexMap<Str, Any | {expression}>,
-    #[serde(skip_serializing_if = "IndexMap::is_empty")]
-    parameters: IndexMap<Str, Str>,
 
-    // FIXME: Implement
-    // /// A literal value or
-    // /// [{expression}](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#runtimeExpression)
-    // /// to use as a request body when calling the target operation.
-    // #[serde(rename = "requestBody")]
-    // request_body: Any | {expression}
+    /// A map representing parameters to pass to an operation as specified with `operationId`
+    /// or identified via `operationRef`. The key is the parameter name to be used, whereas
+    /// the value can be a constant or an expression to be evaluated and passed to the
+    /// linked operation. The parameter name can be qualified using the
+    /// [parameter location](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#parameterIn)
+    /// `[{in}.]{name}` for operations that use the same parameter name in different
+    /// locations (e.g. path.id).
+    #[serde(skip_serializing_if = "IndexMap::is_empty")]
+    parameters: IndexMap<Str, RuntimeExpressionOrValue>,
+
+    /// A literal value or
+    /// [{expression}](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#runtimeExpression)
+    /// to use as a request body when calling the target operation.
+    #[serde(rename = "requestBody", skip_serializing_if = "Option::is_none")]
+    request_body: Option<RuntimeExpressionOrValue>,
+
     /// A description of the link. [CommonMark syntax](http://spec.commonmark.org/) MAY be
     /// used for rich text representation.
     #[serde(skip_serializing_if = "str::is_empty")]
@@ -687,6 +686,14 @@ pub struct Link {
     #[serde(skip_serializing_if = "Option::is_none")]
     server: Option<Server>,
     // TODO: Add "Specification Extensions" https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#specificationExtension
+}
+
+/// Runtime expression or literal value. Used for Link `parameters` and `request_body`.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[serde(untagged)]
+pub enum RuntimeExpressionOrValue {
+    RuntimeExpression(Str),
+    LiteralValue(serde_json::Value),
 }
 
 /// The name of an _existing_ resolvable OAS operation, or a relative or absolute reference to an OAS operation.

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -841,20 +841,28 @@ pub struct Example {
     /// [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
     #[serde(skip_serializing_if = "str::is_empty")]
     pub description: Str,
-    // FIXME: Implement (merge with externalValue as enum)
-    /// Embedded literal example. The `value` field and `externalValue` field are mutually
-    /// exclusive. To represent examples of media types that cannot naturally represented
-    /// in JSON or YAML, use a string value to contain the example, escaping where necessary.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub value: Option<serde_json::Value>,
-    // FIXME: Implement (merge with value as enum)
-    // /// A URL that points to the literal example. This provides the capability to reference
-    // /// examples that cannot easily be included in JSON or YAML documents. The `value` field
-    // /// and `externalValue` field are mutually exclusive.
-    // #[serde(skip_serializing_if = "Option::is_none")]
-    // pub externalValue: Str,
+    /// Embedded literal example or a URL that points to the literal example.
+    #[serde(skip_serializing_if = "Option::is_none", flatten)]
+    pub value: Option<ExampleValue>,
 
     // TODO: Add "Specification Extensions" https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#specificationExtensions}
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub enum ExampleValue {
+    Embedded {
+        /// Embedded literal example. The `value` field and `externalValue` field are mutually
+        /// exclusive. To represent examples of media types that cannot naturally represented
+        /// in JSON or YAML, use a string value to contain the example, escaping where necessary.
+        value: serde_json::Value
+    },
+    External {
+        /// A URL that points to the literal example. This provides the capability to reference
+        /// examples that cannot easily be included in JSON or YAML documents. The `value` field
+        /// and `externalValue` field are mutually exclusive.
+        #[serde(rename = "externalValue")]
+        external_value: Str
+    },
 }
 
 /// Defines a security scheme that can be used by the operations. Supported schemes are

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -479,7 +479,6 @@ pub struct Schema {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nullable: Option<bool>,
 
-    // FIXME: Why can this be a "boolean" (as per the spec)? It doesn't make sense. Here it's not.
     /// Value can be boolean or object. Inline or referenced schema MUST be of a
     /// [Schema Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#schemaObject)
     /// and not a standard JSON Schema.

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -48,8 +48,8 @@ pub struct Spec {
     /// The list of  values includes alternative security requirement objects that can be used.
     /// Only one of the security requirement objects need to be satisfied to authorize a request.
     /// Individual operations can override this definition.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub security: Option<SecurityRequirement>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub security: Vec<SecurityRequirement>,
 
     /// A list of tags used by the specification with additional metadata.
     ///The order of the tags can be used to reflect on their order by the parsing tools.
@@ -315,8 +315,8 @@ pub struct Operation {
     /// This definition overrides any declared top-level
     /// [`security`](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#oasSecurity).
     /// To remove a top-level security declaration, an empty array can be used.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub security: Option<SecurityRequirement>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub security: Vec<SecurityRequirement>,
 
     /// An alternative `server` array to service this operation. If an alternative `server`
     /// object is specified at the Path Item Object or Root level, it will be overridden by

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -44,13 +44,13 @@ pub struct Spec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub components: Option<Components>,
 
-    // FIXME: Implement
-    // /// A declaration of which security mechanisms can be used across the API.
-    // /// The list of  values includes alternative security requirement objects that can be used.
-    // /// Only one of the security requirement objects need to be satisfied to authorize a request.
-    // /// Individual operations can override this definition.
-    // #[serde(skip_serializing_if = "Option::is_none")]
-    // pub security: Option<SecurityRequirement>,
+    /// A declaration of which security mechanisms can be used across the API.
+    /// The list of  values includes alternative security requirement objects that can be used.
+    /// Only one of the security requirement objects need to be satisfied to authorize a request.
+    /// Individual operations can override this definition.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub security: Option<SecurityRequirement>,
+
     /// A list of tags used by the specification with additional metadata.
     ///The order of the tags can be used to reflect on their order by the parsing tools.
     /// Not all tags that are used by the
@@ -309,14 +309,15 @@ pub struct Operation {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deprecated: Option<bool>,
 
-    // FIXME: Implement
-    // /// A declaration of which security mechanisms can be used for this operation. The list of
-    // /// values includes alternative security requirement objects that can be used. Only one
-    // /// of the security requirement objects need to be satisfied to authorize a request.
-    // /// This definition overrides any declared top-level
-    // /// [`security`](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#oasSecurity).
-    // /// To remove a top-level security declaration, an empty array can be used.
-    // pub security: Option<SecurityRequirement>,
+    /// A declaration of which security mechanisms can be used for this operation. The list of
+    /// values includes alternative security requirement objects that can be used. Only one
+    /// of the security requirement objects need to be satisfied to authorize a request.
+    /// This definition overrides any declared top-level
+    /// [`security`](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#oasSecurity).
+    /// To remove a top-level security declaration, an empty array can be used.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub security: Option<SecurityRequirement>,
+
     /// An alternative `server` array to service this operation. If an alternative `server`
     /// object is specified at the Path Item Object or Root level, it will be overridden by
     /// this value.
@@ -947,6 +948,16 @@ pub struct Callback(
     /// A Path Item Object used to define a callback request and expected responses.
     serde_json::Value, // TODO: Add "Specification Extensions" https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#specificationExtensions}
 );
+
+/// # [Security Requirement Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#securityRequirementObject)
+/// Lists the required security schemes to execute this operation.
+/// The name used for each property MUST correspond to a security scheme declared in the [Security Schemes](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#componentsSecuritySchemes) under the [Components Object](#componentsObject).
+///
+/// Security Requirement Objects that contain multiple schemes require that all schemes MUST be satisfied for a request to be authorized.
+/// This enables support for scenarios where multiple query parameters or HTTP headers are required to convey security information.
+///
+/// When a list of Security Requirement Objects is defined on the [OpenAPI Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#oasObject) or [Operation Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#operationObject), only one of the Security Requirement Objects in the list needs to be satisfied to authorize the request.
+pub type SecurityRequirement = IndexMap<Str, Vec<Str>>;
 
 // FIXME: Implement
 // /// Allows configuration of the supported OAuth Flows.

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -657,79 +657,57 @@ pub struct RequestBody {
 ///
 /// See <https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#linkObject>.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct Link {
+    #[serde(flatten)]
+    operation: LinkOperation,
+    // FIXME: Implement
+    // /// A map representing parameters to pass to an operation as specified with `operationId`
+    // /// or identified via `operationRef`. The key is the parameter name to be used, whereas
+    // /// the value can be a constant or an expression to be evaluated and passed to the
+    // /// linked operation. The parameter name can be qualified using the
+    // /// [parameter location](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#parameterIn)
+    // /// `[{in}.]{name}` for operations that use the same parameter name in different
+    // /// locations (e.g. path.id).
+    // parameters: IndexMap<Str, Any | {expression}>,
+    #[serde(skip_serializing_if = "IndexMap::is_empty")]
+    parameters: IndexMap<Str, Str>,
+
+    // FIXME: Implement
+    // /// A literal value or
+    // /// [{expression}](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#runtimeExpression)
+    // /// to use as a request body when calling the target operation.
+    // #[serde(rename = "requestBody")]
+    // request_body: Any | {expression}
+    /// A description of the link. [CommonMark syntax](http://spec.commonmark.org/) MAY be
+    /// used for rich text representation.
+    #[serde(skip_serializing_if = "str::is_empty")]
+    description: Str,
+
+    /// A server object to be used by the target operation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    server: Option<Server>,
+    // TODO: Add "Specification Extensions" https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#specificationExtension
+}
+
+/// The name of an _existing_ resolvable OAS operation, or a relative or absolute reference to an OAS operation.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(untagged)]
-pub enum Link {
-    /// A relative or absolute reference to an OAS operation. This field is mutually exclusive
-    /// of the `operationId` field, and MUST point to an
-    /// [Operation Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#operationObject).
-    /// Relative `operationRef` values MAY be used to locate an existing
-    /// [Operation Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#operationObject)
-    /// in the OpenAPI definition.
-    Ref {
-        #[serde(rename = "operationRef")]
-        operation_ref: Str,
-
-        // FIXME: Implement
-        // /// A map representing parameters to pass to an operation as specified with `operationId`
-        // /// or identified via `operationRef`. The key is the parameter name to be used, whereas
-        // /// the value can be a constant or an expression to be evaluated and passed to the
-        // /// linked operation. The parameter name can be qualified using the
-        // /// [parameter location](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#parameterIn)
-        // /// `[{in}.]{name}` for operations that use the same parameter name in different
-        // /// locations (e.g. path.id).
-        // parameters: IndexMap<Str, Any | {expression}>,
-        #[serde(skip_serializing_if = "IndexMap::is_empty")]
-        parameters: IndexMap<Str, Str>,
-
-        // FIXME: Implement
-        // /// A literal value or
-        // /// [{expression}](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#runtimeExpression)
-        // /// to use as a request body when calling the target operation.
-        // #[serde(rename = "requestBody")]
-        // request_body: Any | {expression}
-        /// A description of the link. [CommonMark syntax](http://spec.commonmark.org/) MAY be
-        /// used for rich text representation.
-        #[serde(skip_serializing_if = "str::is_empty")]
-        description: Str,
-
-        /// A server object to be used by the target operation.
-        #[serde(skip_serializing_if = "Option::is_none")]
-        server: Option<Server>,
-        // TODO: Add "Specification Extensions" https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#specificationExtension
-    },
-    /// The name of an _existing_, resolvable OAS operation, as defined with a unique
-    /// `operationId`. This field is mutually exclusive of the `operationRef` field.
+pub enum LinkOperation {
     Id {
+        /// The name of an _existing_, resolvable OAS operation, as defined with a unique
+        /// `operationId`. This field is mutually exclusive of the `operationRef` field.
         #[serde(rename = "operationId")]
         operation_id: Str,
-
-        // FIXME: Implement
-        // /// A map representing parameters to pass to an operation as specified with `operationId`
-        // /// or identified via `operationRef`. The key is the parameter name to be used, whereas
-        // /// the value can be a constant or an expression to be evaluated and passed to the
-        // /// linked operation. The parameter name can be qualified using the
-        // /// [parameter location](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#parameterIn)
-        // /// `[{in}.]{name}` for operations that use the same parameter name in different
-        // /// locations (e.g. path.id).
-        // parameters: IndexMap<Str, Any | {expression}>,
-        #[serde(skip_serializing_if = "IndexMap::is_empty")]
-        parameters: IndexMap<Str, Str>,
-
-        // FIXME: Implement
-        // /// A literal value or
-        // /// [{expression}](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#runtimeExpression)
-        // /// to use as a request body when calling the target operation.
-        // #[serde(rename = "requestBody")]
-        // request_body: Any | {expression}
-        /// A description of the link. [CommonMark syntax](http://spec.commonmark.org/) MAY be
-        /// used for rich text representation.
-        #[serde(skip_serializing_if = "str::is_empty")]
-        description: Str,
-
-        /// A server object to be used by the target operation.
-        #[serde(skip_serializing_if = "Option::is_none")]
-        server: Option<Server>,
-        // TODO: Add "Specification Extensions" https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#specificationExtension
+    },
+    Ref {
+        /// A relative or absolute reference to an OAS operation. This field is mutually exclusive
+        /// of the `operationId` field, and MUST point to an
+        /// [Operation Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#operationObject).
+        /// Relative `operationRef` values MAY be used to locate an existing
+        /// [Operation Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#operationObject)
+        /// in the OpenAPI definition.
+        #[serde(rename = "operationRef")]
+        operation_ref: Str,
     },
 }
 

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -175,7 +175,6 @@ pub struct PathItem {
     /// [Path Item Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#pathItemObject).
     /// If there are conflicts between the referenced definition and this Path Item's definition,
     /// the behavior is undefined.
-    // FIXME: Should this ref be moved to an enum?
     #[serde(skip_serializing_if = "str::is_empty", rename = "$ref")]
     pub reference: Str,
 

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -7,8 +7,7 @@ use crate::{
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use serde_json;
-use url;
-use url_serde;
+use url::Url;
 
 /// top level document
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
@@ -92,16 +91,6 @@ pub struct Info {
     /// The license information for the exposed API.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub license: Option<License>,
-}
-
-/// Wraper around `url::Url` to fix serde issue
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
-pub struct Url(#[serde(with = "url_serde")] url::Url);
-
-impl Url {
-    pub fn parse<S: AsRef<str>>(input: S) -> std::result::Result<Url, url::ParseError> {
-        url::Url::parse(input.as_ref()).map(Url)
-    }
 }
 
 /// Contact information for the exposed API.

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -815,7 +815,9 @@ pub struct Example {
     // TODO: Add "Specification Extensions" https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#specificationExtensions}
 }
 
+/// Embedded literal example or a URL that points to the literal example.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[serde(untagged)]
 pub enum ExampleValue {
     Embedded {
         /// Embedded literal example. The `value` field and `externalValue` field are mutually


### PR DESCRIPTION
TLDR: Updated cargo deps, discarded or applied `FIXME`s, added missing fields necessary for kdy1/rweb#64 and kdy1/rweb#65 to proceed.

For discarded FIXMEs see [responsible] commit's description for details &/| reasoning.