### PR TITLE
Schema - component or inline

### DIFF
--- a/src/v3_0/components.rs
+++ b/src/v3_0/components.rs
@@ -1,6 +1,6 @@
 use crate::{
     v3_0::{
-        Callback, Example, Header, Link, Parameter, RequestBody, Response, Schema, SecurityScheme,
+        Callback, Example, Header, Link, Parameter, RequestBody, Response, ComponentOrInlineSchema, SecurityScheme,
     },
     Str,
 };
@@ -27,7 +27,7 @@ pub enum ObjectOrReference<T> {
 pub struct Components {
     /// An object to hold reusable Schema Objects.
     #[serde(skip_serializing_if = "IndexMap::is_empty")]
-    pub schemas: IndexMap<Str, ObjectOrReference<Schema>>,
+    pub schemas: IndexMap<Str, ComponentOrInlineSchema>,
 
     /// An object to hold reusable Response Objects.
     #[serde(skip_serializing_if = "IndexMap::is_empty")]

--- a/src/v3_0/components.rs
+++ b/src/v3_0/components.rs
@@ -1,6 +1,6 @@
 use crate::{
     v3_0::{
-        Callback, Example, Header, Link, Parameter, RequestBody, Response, ComponentOrInlineSchema, SecurityScheme,
+        Callback, Example, Header, Link, Parameter, RequestBody, Response, Schema, SecurityScheme,
     },
     Str,
 };
@@ -27,7 +27,7 @@ pub enum ObjectOrReference<T> {
 pub struct Components {
     /// An object to hold reusable Schema Objects.
     #[serde(skip_serializing_if = "IndexMap::is_empty")]
-    pub schemas: IndexMap<Str, ComponentOrInlineSchema>,
+    pub schemas: IndexMap<Str, ObjectOrReference<Schema>>,
 
     /// An object to hold reusable Response Objects.
     #[serde(skip_serializing_if = "IndexMap::is_empty")]

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -507,7 +507,7 @@ pub enum ComponentOrInlineSchema {
 		/// Serialized as [JSON reference](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03)
 		/// path to the definition within the specification document
 		#[serde(rename = "$ref", serialize_with = "component_ser_as_ref::serialize", deserialize_with = "component_ser_as_ref::deserialize")]
-    	component: Str
+    	name: Str
 	},
 	Inline(Schema),
 	// Add "ExtRef" variant if support for externally referenced schemas (neither inline nor components) is needed

--- a/src/v3_0/schema.rs
+++ b/src/v3_0/schema.rs
@@ -399,7 +399,7 @@ pub struct Parameter {
 pub enum ParameterRepresentation {
     Simple {
         /// The schema defining the type used for the parameter.
-        schema: ObjectOrReference<Schema>,
+        schema: ComponentOrInlineSchema,
     },
     Content {
         /// A map containing the representations for the parameter. The key is the media type and the value describes it. The map MUST only contain one entry.
@@ -526,13 +526,6 @@ pub enum ComponentOrInlineSchema {
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct Schema {
-    /// [JSON reference](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03)
-    /// path to another definition
-    #[serde(skip_serializing_if = "str::is_empty")]
-    #[serde(rename = "$ref")]
-    pub ref_path: Str,
-
-
     // This is from 3.0.1; Differs for 3.1
     // vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
     // The following properties are taken directly from the JSON Schema definition and follow the same specifications:
@@ -572,10 +565,10 @@ pub struct Schema {
     pub format: Str,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub items: Option<Box<Schema>>,
+    pub items: Option<Box<ComponentOrInlineSchema>>,
 
     #[serde(skip_serializing_if = "IndexMap::is_empty")]
-    pub properties: IndexMap<Str, Schema>,
+    pub properties: IndexMap<Str, ComponentOrInlineSchema>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub read_only: Option<bool>,
@@ -592,7 +585,7 @@ pub struct Schema {
     ///
     /// See <https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#properties>.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub additional_properties: Option<ObjectOrReference<Box<Schema>>>,
+    pub additional_properties: Option<Box<ComponentOrInlineSchema>>,
 
     /// A free-form property to include an example of an instance for this schema.
     /// To represent examples that cannot be naturally represented in JSON or YAML,
@@ -617,17 +610,17 @@ pub struct Schema {
     /// Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard
     /// JSON Schema.
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub all_of: Vec<ObjectOrReference<Schema>>,
+    pub all_of: Vec<ComponentOrInlineSchema>,
 
     /// Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard
     /// JSON Schema.
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub one_of: Vec<ObjectOrReference<Schema>>,
+    pub one_of: Vec<ComponentOrInlineSchema>,
 
     /// Inline or referenced schema MUST be of a [Schema Object](#schemaObject) and not a standard
     /// JSON Schema.
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub any_of: Vec<ObjectOrReference<Schema>>,
+    pub any_of: Vec<ComponentOrInlineSchema>,
 
 
     // JSON Schema Validation
@@ -731,7 +724,7 @@ pub struct Header {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub required: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub schema: Option<Schema>,
+    pub schema: Option<ComponentOrInlineSchema>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "uniqueItems")]
     pub unique_items: Option<bool>,
@@ -864,7 +857,7 @@ pub enum LinkOperation {
 pub struct MediaType {
     /// The schema defining the type used for the request body.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub schema: Option<ObjectOrReference<Schema>>,
+    pub schema: Option<ComponentOrInlineSchema>,
 
     /// Example of the media type.
     #[serde(flatten, skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
This goes hand in hand with kdy1/rweb#93 (merging just one _will break_).

Json schema does not allow additional properties next to `$ref`. This PR explicits such behaviour by separating `Schema` into a `ComponentOrInlineSchema` enum - either containing component name, or inlined schema.

For convenience, in Rust the component name is stored pure, and only transformed into complete JSON `$ref` upon serialization/deserialziation.